### PR TITLE
Fix SD_DMATransmitCplt

### DIFF
--- a/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sd.c
+++ b/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sd.c
@@ -3222,16 +3222,45 @@ HAL_StatusTypeDef HAL_SD_Abort_IT(SD_HandleTypeDef *hsd)
 
 #if !defined(STM32L4P5xx) && !defined(STM32L4Q5xx) && !defined(STM32L4R5xx) && !defined(STM32L4R7xx) && !defined(STM32L4R9xx) && !defined(STM32L4S5xx) && !defined(STM32L4S7xx) && !defined(STM32L4S9xx)
 /**
-  * @brief  DMA SD transmit process complete callback
-  * @param  hdma DMA handle
-  * @retval None
-  */
-static void SD_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+ * @brief  DMA SD transmit process complete callback
+ * @param  hdma DMA handle
+ * @retval None
+ */
+static void SD_DMATransmitCplt(DMA_HandleTypeDef* hdma)
 {
-  SD_HandleTypeDef* hsd = (SD_HandleTypeDef* )(hdma->Parent);
+    SD_HandleTypeDef* hsd = (SD_HandleTypeDef*)(hdma->Parent);
+    uint32_t          errorstate;
 
-  /* Enable DATAEND Interrupt */
-  __HAL_SD_ENABLE_IT(hsd, (SDMMC_IT_DATAEND));
+    /* Send stop command in multiblock write */
+    if (hsd->Context == (SD_CONTEXT_WRITE_MULTIPLE_BLOCK | SD_CONTEXT_DMA))
+    {
+        errorstate = SDMMC_CmdStopTransfer(hsd->Instance);
+        if (errorstate != HAL_SD_ERROR_NONE)
+        {
+            hsd->ErrorCode |= errorstate;
+#if (USE_HAL_SD_REGISTER_CALLBACKS == 1)
+            hsd->ErrorCallback(hsd);
+#else
+            HAL_SD_ErrorCallback(hsd);
+#endif
+        }
+    }
+
+    /* Disable the DMA transfer for transmit request by setting the DMAEN bit
+        in the SD DCTRL register */
+    hsd->Instance->DCTRL &= (uint32_t) ~((uint32_t)SDMMC_DCTRL_DMAEN);
+
+    /* Clear all the static flags */
+    __HAL_SD_CLEAR_FLAG(hsd, SDMMC_STATIC_DATA_FLAGS);
+
+    hsd->State   = HAL_SD_STATE_READY;
+    hsd->Context = SD_CONTEXT_NONE;
+
+#if (USE_HAL_SD_REGISTER_CALLBACKS == 1)
+    hsd->TxCpltCallback(hsd);
+#else
+    HAL_SD_TxCpltCallback(hsd);
+#endif
 }
 
 /**


### PR DESCRIPTION
Fixed SD_DMATransmitCplt to actually do what it's supposed to do. It now properly checks the status of the transfer, clears the interrupt/request flags and call the SD DMA transfer complete callback function.

