### PR TITLE
Fix USB MSC more than 2 LUNs support

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_bot.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc_bot.c
@@ -255,7 +255,7 @@ static void  MSC_BOT_CBW_Decode(USBD_HandleTypeDef *pdev)
 
   if ((USBD_LL_GetRxDataSize(pdev, MSC_EPOUT_ADDR) != USBD_BOT_CBW_LENGTH) ||
       (hmsc->cbw.dSignature != USBD_BOT_CBW_SIGNATURE) ||
-      (hmsc->cbw.bLUN > 1U) || (hmsc->cbw.bCBLength < 1U) ||
+      (hmsc->cbw.bLUN > hmsc->max_lun) || (hmsc->cbw.bCBLength < 1U) ||
       (hmsc->cbw.bCBLength > 16U))
   {
     SCSI_SenseCode(pdev, hmsc->cbw.bLUN, ILLEGAL_REQUEST, INVALID_CDB);


### PR DESCRIPTION
Fix support more than 2 LUNs into USB MSC device

Now it successfully recognized 4 LUNS: 
```
kernel: [ 1969.997185] scsi 8:0:0:0: Direct-Access     STM      MicroSD Device   0.01 PQ: 0 ANSI: 2
kernel: [ 1969.997830] scsi 8:0:0:1: Direct-Access     STM      EEPROM           0.01 PQ: 0 ANSI: 2
kernel: [ 1969.998390] scsi 8:0:0:2: Direct-Access     STM      System           0.01 PQ: 0 ANSI: 2
kernel: [ 1969.999059] scsi 8:0:0:3: Direct-Access     STM      Test             0.01 PQ: 0 ANSI: 2
kernel: [ 1969.999505] sd 8:0:0:0: Attached scsi generic sg7 type 0
```
