### PR TITLE
Parameter name typo fixed

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
@@ -173,7 +173,7 @@ uint8_t USBD_LL_IsStallEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
   * @retval USBD Status
   */
 USBD_StatusTypeDef USBD_LL_SetUSBAddress(USBD_HandleTypeDef *pdev,
-                                         uint8_t dev_addr)
+                                         uint8_t ep_addr)
 {
   UNUSED(pdev);
   UNUSED(ep_addr);


### PR DESCRIPTION
Parameter name did not match UNUSED block.

Edited for consistency with other similar functions.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeL4/blob/master/CONTRIBUTING.md) file.
