### PR TITLE
Minor linter fixes

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
@@ -241,6 +241,7 @@ uint32_t USBD_LL_GetRxDataSize(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
   */
 void *USBD_static_malloc(uint32_t size)
 {
+  UNUSED(size);
   static uint32_t mem[(sizeof(USBD_HID_HandleTypeDef) / 4) + 1]; /* On 32-bit boundary */
   return mem;
 }
@@ -252,7 +253,7 @@ void *USBD_static_malloc(uint32_t size)
   */
 void USBD_static_free(void *p)
 {
-
+  UNUSED(p);
 }
 
 /**

--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_conf_template.c
@@ -173,7 +173,7 @@ uint8_t USBD_LL_IsStallEP(USBD_HandleTypeDef *pdev, uint8_t ep_addr)
   * @retval USBD Status
   */
 USBD_StatusTypeDef USBD_LL_SetUSBAddress(USBD_HandleTypeDef *pdev,
-                                         uint8_t dev_addr)
+                                         uint8_t ep_addr)
 {
   UNUSED(pdev);
   UNUSED(ep_addr);


### PR DESCRIPTION
Fixed argument typo and added UNUSED() macro calls for unused parameters.
