### PR TITLE
Fix compiler warnings when using -Wextra flag

### DIFF
--- a/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_exti.c
+++ b/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_exti.c
@@ -539,7 +539,7 @@ uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   uint32_t offset;
 
 #ifndef USE_FULL_ASSERT /* Prevent compiler warning in case of -Wextra */
-  (void) Edge;
+  UNUSED(Edge);
 #endif
 
   /* Check parameters */
@@ -577,7 +577,7 @@ void HAL_EXTI_ClearPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   uint32_t offset;
 
 #ifndef USE_FULL_ASSERT /* Prevent compiler warning in case of -Wextra */
-  (void) Edge;
+  UNUSED(Edge);
 #endif
 
   /* Check parameters */

--- a/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_exti.c
+++ b/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_exti.c
@@ -538,6 +538,10 @@ uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   uint32_t maskline;
   uint32_t offset;
 
+#ifndef USE_FULL_ASSERT /* Prevent compiler warning in case of -Wextra */
+  (void) Edge;
+#endif
+
   /* Check parameters */
   assert_param(IS_EXTI_LINE(hexti->Line));
   assert_param(IS_EXTI_CONFIG_LINE(hexti->Line));
@@ -571,6 +575,10 @@ void HAL_EXTI_ClearPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   __IO uint32_t *regaddr;
   uint32_t maskline;
   uint32_t offset;
+
+#ifndef USE_FULL_ASSERT /* Prevent compiler warning in case of -Wextra */
+  (void) Edge;
+#endif
 
   /* Check parameters */
   assert_param(IS_EXTI_LINE(hexti->Line));

--- a/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc.c
+++ b/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc.c
@@ -4537,6 +4537,8 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide, uint3
       supported_pwr_class = ((hmmc->Ext_CSD[(MMC_EXT_CSD_PWR_CL_52_INDEX/4)] >> MMC_EXT_CSD_PWR_CL_52_POS) & 0x000000FFU);
     }
     else
+#else /* Prevent compiler warning in case of -Wextra */
+    (void) Speed;
 #endif
     {
       /* Field PWR_CL_26_xxx [201 or 203] */

--- a/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc.c
+++ b/Drivers/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_mmc.c
@@ -4538,7 +4538,7 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide, uint3
     }
     else
 #else /* Prevent compiler warning in case of -Wextra */
-    (void) Speed;
+    UNUSED(Speed);
 #endif
     {
       /* Field PWR_CL_26_xxx [201 or 203] */


### PR DESCRIPTION
During compilation with `-pedantic` and `-Wextra` flags, a few warnings have occurred in HAL library. My fix neither does remove nor add any functionality, i have just void casted arguments unused in some situations (for example when `USE_FULL_ASSERT` is not enabled).