### PR TITLE
[Prj] fix start client connection for UDP sockets

### DIFF
--- a/Projects/B-L475E-IOT01A/Applications/WiFi/Common/Src/es_wifi.c
+++ b/Projects/B-L475E-IOT01A/Applications/WiFi/Common/Src/es_wifi.c
@@ -1761,13 +1761,13 @@ ES_WIFI_Status_t ES_WIFI_StartClientConnection(ES_WIFIObject_t *Obj, ES_WIFI_Con
     ret = AT_ExecuteCommand(Obj, Obj->CmdData, Obj->CmdData);
   }
 
-  if ((ret == ES_WIFI_STATUS_OK)&& ((conn->Type == ES_WIFI_TCP_CONNECTION) || (conn->Type == ES_WIFI_TCP_SSL_CONNECTION)))
+  if (ret == ES_WIFI_STATUS_OK)
   {
     sprintf((char*)Obj->CmdData,"P4=%d\r", conn->RemotePort);
     ret = AT_ExecuteCommand(Obj, Obj->CmdData, Obj->CmdData);
   }
 
-  if ((ret == ES_WIFI_STATUS_OK) && ((conn->Type == ES_WIFI_TCP_CONNECTION) || (conn->Type == ES_WIFI_TCP_SSL_CONNECTION)))
+  if (ret == ES_WIFI_STATUS_OK)
   {
     sprintf((char*)Obj->CmdData,"P3=%d.%d.%d.%d\r", conn->RemoteIP[0],conn->RemoteIP[1],
             conn->RemoteIP[2],conn->RemoteIP[3]);

--- a/Projects/B-L4S5I-IOT01A/Applications/WiFi/Common/Src/es_wifi.c
+++ b/Projects/B-L4S5I-IOT01A/Applications/WiFi/Common/Src/es_wifi.c
@@ -1773,13 +1773,13 @@ ES_WIFI_Status_t ES_WIFI_StartClientConnection(ES_WIFIObject_t *Obj, ES_WIFI_Con
     ret = AT_ExecuteCommand(Obj, Obj->CmdData, Obj->CmdData);
   }
 
-  if ((ret == ES_WIFI_STATUS_OK)&& ((conn->Type == ES_WIFI_TCP_CONNECTION) || (conn->Type == ES_WIFI_TCP_SSL_CONNECTION)))
+  if (ret == ES_WIFI_STATUS_OK)
   {
     sprintf((char*)Obj->CmdData,"P4=%d\r", conn->RemotePort);
     ret = AT_ExecuteCommand(Obj, Obj->CmdData, Obj->CmdData);
   }
 
-  if ((ret == ES_WIFI_STATUS_OK) && ((conn->Type == ES_WIFI_TCP_CONNECTION) || (conn->Type == ES_WIFI_TCP_SSL_CONNECTION)))
+  if (ret == ES_WIFI_STATUS_OK)
   {
     sprintf((char*)Obj->CmdData,"P3=%d.%d.%d.%d\r", conn->RemoteIP[0],conn->RemoteIP[1],
             conn->RemoteIP[2],conn->RemoteIP[3]);


### PR DESCRIPTION
This pull-request fixes an issue with the `ES_WIFI_StartClientConnection` function when using UDP socket: commands P3 and P4 (respectively to set remote IP address and port) must be executed not only for TCP/SSL connection. Indeed, while trying to open an UDP socket, we have to set the UDP server address and port!!

Reference documentation from Inventek at https://www.inventeksys.com/iwin/wp-content/uploads/IWIN_Command_Set_Users_Manual.pdf does not limit executing P3 and P4 commands to TCP/SSL.

Implementation from getting-started example from Azure RTOS also made this modification. See https://github.com/eclipse-threadx/getting-started/blob/37ff82f757070f3fa5364acb1ac06fcc7a5b9d38/STMicroelectronics/B-L475E-IOT01A/lib/netx_driver/inventek/es_wifi.c#L1635.